### PR TITLE
fix(writer): fixd write == nil

### DIFF
--- a/nimo-shake/checkpoint/writer.go
+++ b/nimo-shake/checkpoint/writer.go
@@ -1,6 +1,8 @@
 package checkpoint
 
 import (
+	"reflect"
+
 	LOG "github.com/vinllen/log4go"
 )
 
@@ -37,7 +39,7 @@ type Writer interface {
 }
 
 func NewWriter(name, address, db string) Writer {
-	var w Writer
+	var w Writer = nil
 	switch name {
 	case CheckpointWriterTypeMongo:
 		w = NewMongoWriter(address, db)
@@ -46,9 +48,19 @@ func NewWriter(name, address, db string) Writer {
 	default:
 		LOG.Crashf("unknown checkpoint writer[%v]", name)
 	}
-	if w == nil {
+
+	if IsNil(w) {
 		LOG.Crashf("create checkpoint writer[%v] failed", name)
-		return nil
 	}
+
 	return w
+}
+
+func IsNil(w Writer) bool {
+	if w == nil {
+		return true
+	}
+
+	v := reflect.ValueOf(w)
+	return v.Kind() == reflect.Ptr && v.IsNil()
 }

--- a/nimo-shake/writer/writer.go
+++ b/nimo-shake/writer/writer.go
@@ -42,7 +42,7 @@ func NewWriter(name, address string, ns utils.NS, logLevel string) Writer {
 	}
 
 	if IsNil(w) {
-		LOG.Crashf("create checkpoint writer[%v] failed", name)
+		LOG.Crashf("create writer[%v] failed", name)
 	}
 
 	return w


### PR DESCRIPTION
修复
Frame 1: /home/banfushen/NimoShake/nimo-shake/full-sync/document-syncer.go:51 (PC: 1038afc)
    46:         w := writer.NewWriter(conf.Options.TargetType, conf.Options.TargetAddress, ns, conf.Options.LogLevel)
    47:         if w == nil {
    48:                 LOG.Crashf("tableSyncer[%v] documentSyncer[%v] create writer failed", tableSyncerId, table)
    49:         }
    50:
=>  51:         w.PassTableDesc(tableDescribe)
    52:
    53:         return &documentSyncer{
    54:                 tableSyncerId:    tableSyncerId,
    55:                 id:               id,
    56:                 inputChan:        inputChan,
(dlv) print w
nimo-shake/writer.Writer(*nimo-shake/writer.MongoCommunityWriter) nil
(dlv) print w == nil
false

writer == nil 无法正确判断