### PR TITLE
feat(nimo-full-check): 新增 checkMode 参数支持双向校验

### DIFF
--- a/nimo-full-check/checker/checker.go
+++ b/nimo-full-check/checker/checker.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"sync"
 
+	checkUtils "nimo-full-check/common"
 	conf "nimo-full-check/configure"
 	shakeUtils "nimo-shake/common"
 	shakeFilter "nimo-shake/filter"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	LOG "github.com/vinllen/log4go"
 	"go.mongodb.org/mongo-driver/bson"
@@ -27,21 +29,39 @@ func NewChecker(dynamoSession *dynamodb.DynamoDB, mongoClient *shakeUtils.MongoC
 }
 
 func (c *Checker) Run() error {
-	// fetch all tables
-	LOG.Info("start fetching table list")
-	rawTableList, err := shakeUtils.FetchTableList(c.dynamoSession)
-	if err != nil {
-		return fmt.Errorf("fetch table list failed[%v]", err)
-	}
-	LOG.Info("finish fetching table list: %v", rawTableList)
+	LOG.Info("start checker with mode[%v]", conf.Opts.CheckMode)
 
-	tableList := shakeFilter.FilterList(rawTableList)
+	var tableList []string
+	var err error
+
+	if conf.Opts.CheckMode == checkUtils.CheckModeMongoDB {
+		// MongoDB as baseline: fetch table list from MongoDB, verify against DynamoDB
+		tableList, err = c.fetchMongoTableList()
+		if err != nil {
+			return fmt.Errorf("fetch mongodb table list failed[%v]", err)
+		}
+
+		// check if tables exist in DynamoDB
+		if err := c.checkTableExistInDynamoDB(tableList); err != nil {
+			return fmt.Errorf("check table exist in dynamodb failed[%v]", err)
+		}
+	} else {
+		// DynamoDB as baseline: fetch table list from DynamoDB, verify against MongoDB
+		rawTableList, err := shakeUtils.FetchTableList(c.dynamoSession)
+		if err != nil {
+			return fmt.Errorf("fetch dynamodb table list failed[%v]", err)
+		}
+		LOG.Info("finish fetching dynamodb table list: %v", rawTableList)
+
+		tableList = shakeFilter.FilterList(rawTableList)
+
+		// check if tables exist in MongoDB
+		if err := c.checkTableExistInMongoDB(tableList); err != nil {
+			return fmt.Errorf("check table exist in mongodb failed[%v]", err)
+		}
+	}
+
 	LOG.Info("filter table list: %v", tableList)
-
-	// check table exist
-	if err := c.checkTableExist(tableList); err != nil {
-		return fmt.Errorf("check table exist failed[%v]", err)
-	}
 
 	// reset parallel if needed
 	parallel := conf.Opts.Parallel
@@ -64,8 +84,8 @@ func (c *Checker) Run() error {
 					break
 				}
 
-				LOG.Info("documentChecker[%v] starts checking table[%v]", id, table)
-				dc := NewDocumentChecker(id, table, c.dynamoSession)
+				LOG.Info("documentChecker[%v] starts checking table[%v] with mode[%v]", id, table, conf.Opts.CheckMode)
+				dc := NewDocumentChecker(id, table, c.dynamoSession, c.mongoClient)
 				dc.Run()
 
 				LOG.Info("documentChecker[%v] finishes checking table[%v]", id, table)
@@ -79,13 +99,28 @@ func (c *Checker) Run() error {
 	return nil
 }
 
-func (c *Checker) checkTableExist(tableList []string) error {
+// fetchMongoTableList fetches collection list from MongoDB
+func (c *Checker) fetchMongoTableList() ([]string, error) {
+	LOG.Info("start fetching mongodb collection list")
 	collections, err := c.mongoClient.Client.Database(conf.Opts.Id).ListCollectionNames(context.TODO(), bson.M{})
 	if err != nil {
-		return fmt.Errorf("get target collection names error[%v]", err)
+		return nil, fmt.Errorf("get mongodb collection names error[%v]", err)
+	}
+	LOG.Info("finish fetching mongodb collection list: %v", collections)
+
+	// apply filter rules
+	tableList := shakeFilter.FilterList(collections)
+	return tableList, nil
+}
+
+// checkTableExistInMongoDB checks if tables exist in MongoDB (original logic)
+func (c *Checker) checkTableExistInMongoDB(tableList []string) error {
+	collections, err := c.mongoClient.Client.Database(conf.Opts.Id).ListCollectionNames(context.TODO(), bson.M{})
+	if err != nil {
+		return fmt.Errorf("get mongodb collection names error[%v]", err)
 	}
 
-	LOG.Info("all table: %v", collections)
+	LOG.Info("mongodb collections: %v", collections)
 
 	collectionsMp := shakeUtils.StringListToMap(collections)
 	notExist := make([]string, 0)
@@ -96,7 +131,41 @@ func (c *Checker) checkTableExist(tableList []string) error {
 	}
 
 	if len(notExist) != 0 {
-		return fmt.Errorf("table not exist on the target side: %v", notExist)
+		return fmt.Errorf("table not exist in mongodb: %v", notExist)
 	}
+	return nil
+}
+
+// checkTableExistInDynamoDB checks if tables exist in DynamoDB
+func (c *Checker) checkTableExistInDynamoDB(tableList []string) error {
+	dynamoTables, err := shakeUtils.FetchTableList(c.dynamoSession)
+	if err != nil {
+		return fmt.Errorf("fetch dynamodb table list error[%v]", err)
+	}
+
+	LOG.Info("dynamodb tables: %v", dynamoTables)
+
+	tablesMp := shakeUtils.StringListToMap(dynamoTables)
+	notExist := make([]string, 0)
+	for _, table := range tableList {
+		if _, ok := tablesMp[table]; !ok {
+			notExist = append(notExist, table)
+		}
+	}
+
+	if len(notExist) != 0 {
+		return fmt.Errorf("table not exist in dynamodb: %v", notExist)
+	}
+
+	// additional check for each table's details (ensure table is accessible)
+	for _, table := range tableList {
+		_, err := c.dynamoSession.DescribeTable(&dynamodb.DescribeTableInput{
+			TableName: aws.String(table),
+		})
+		if err != nil {
+			return fmt.Errorf("describe dynamodb table[%v] failed[%v]", table, err)
+		}
+	}
+
 	return nil
 }

--- a/nimo-full-check/checker/sample.go
+++ b/nimo-full-check/checker/sample.go
@@ -21,11 +21,9 @@ func NewSample(sampleCnt, totalCnt int64) *Sample {
 }
 
 func (s *Sample) Hit() bool {
-	if s.sampleCnt >= s.totalCnt {
+	// sampleCnt == 0 means disable sampling, compare all data
+	if s.sampleCnt == 0 || s.sampleCnt >= s.totalCnt {
 		return true
-	}
-	if s.sampleCnt == 0 {
-		return false
 	}
 
 	return s.source.Int63n(s.totalCnt) < s.sampleCnt

--- a/nimo-full-check/common/common.go
+++ b/nimo-full-check/common/common.go
@@ -3,3 +3,11 @@ package utils
 var (
 	Version = "$"
 )
+
+// Check modes for data verification
+// TODO: Add CheckModeBoth for bidirectional verification (check both directions in one run),
+//       and CheckModeCount for count-only verification (based on bidirectional mode, since DynamoDB lacks precise count)
+const (
+	CheckModeMongoDB  = "mongodb"  // MongoDB as baseline: iterate MongoDB, verify against DynamoDB
+	CheckModeDynamoDB = "dynamodb" // DynamoDB as baseline: iterate DynamoDB, verify against MongoDB (default mode)
+)

--- a/nimo-full-check/configure/conf.go
+++ b/nimo-full-check/configure/conf.go
@@ -13,11 +13,12 @@ var Opts struct {
 	TargetAddress         string `short:"t" long:"targetAddress" description:"mongodb target address"`
 	DiffOutputFile        string `short:"d" long:"diffOutputFile" default:"nimo-full-check-diff" description:"diff output file name"`
 	Parallel              int    `short:"p" long:"parallel" default:"16" description:"how many threads used to compare, default is 16"`
-	Sample                int64  `short:"e" long:"sample" default:"1000" description:"comparison sample number for each table, 0 means disable"`
+	Sample                int64  `short:"e" long:"sample" default:"1000" description:"comparison sample number for each table, 0 means compare all"`
 	//IndexPrimary          bool   `short:"m" long:"indexPrimary" description:"enable compare primary index"`
 	//IndexUser             bool   `long:"indexUser" description:"enable compare user index"`
 	FilterCollectionWhite string `long:"filterCollectionWhite" default:"" description:"only compare the given tables, split by ';'"`
 	FilterCollectionBlack string `long:"filterCollectionBlack" default:"" description:"do not compare the given tables, split by ';'"`
 	ConvertType           string `short:"c" long:"convertType" default:"change" description:"convert type"`
+	CheckMode             string `short:"m" long:"checkMode" default:"dynamodb" description:"check mode: mongodb (use mongodb as baseline, check dynamodb) or dynamodb (use dynamodb as baseline, check mongodb)"`
 	Version               bool   `short:"v" long:"version" description:"print version"`
 }

--- a/nimo-full-check/main/main.go
+++ b/nimo-full-check/main/main.go
@@ -28,7 +28,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	// 若err != nil, 会自动打印错误到 stderr
+	// if err != nil, error will be printed to stderr automatically
 	if err != nil {
 		if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {
 			os.Exit(0)
@@ -104,6 +104,11 @@ func sanitizeOptions() error {
 	} else if conf.Opts.ConvertType != shakeUtils.ConvertMTypeChange {
 		return fmt.Errorf("convertType[%v] illegal, only support %v",
 			conf.Opts.ConvertType, shakeUtils.ConvertMTypeChange)
+	}
+
+	if conf.Opts.CheckMode != utils.CheckModeMongoDB && conf.Opts.CheckMode != utils.CheckModeDynamoDB {
+		return fmt.Errorf("checkMode[%v] illegal, must be '%v' or '%v'",
+			conf.Opts.CheckMode, utils.CheckModeMongoDB, utils.CheckModeDynamoDB)
 	}
 
 	return nil

--- a/nimo-shake/full-sync/document-syncer.go
+++ b/nimo-shake/full-sync/document-syncer.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	LOG "github.com/vinllen/log4go"
-	"nimo-shake/protocal"
+	"nimo-shake/protocol"
 	"sync/atomic"
 )
 
@@ -100,7 +100,7 @@ func (ds *documentSyncer) Run() {
 				batchGroup = append(batchGroup, data)
 			} else {
 				switch v := data.(type) {
-				case protocal.RawData:
+				case protocol.RawData:
 					if v.Size > 0 {
 						batchGroup = append(batchGroup, v.Data)
 						batchGroupSize += v.Size

--- a/nimo-shake/full-sync/table-syncer.go
+++ b/nimo-shake/full-sync/table-syncer.go
@@ -10,7 +10,7 @@ import (
 
 	utils "nimo-shake/common"
 	conf "nimo-shake/configure"
-	"nimo-shake/protocal"
+	"nimo-shake/protocol"
 	"nimo-shake/qps"
 	"nimo-shake/writer"
 
@@ -31,7 +31,7 @@ type tableSyncer struct {
 	sourceTableDescribe *dynamodb.TableDescription
 	fetcherChan         chan *dynamodb.ScanOutput // chan between fetcher and parser
 	parserChan          chan interface{}          // chan between parser and writer
-	converter           protocal.Converter        // converter
+	converter           protocol.Converter        // converter
 	collectionMetric    *utils.CollectionMetric
 }
 
@@ -51,7 +51,7 @@ func NewTableSyncer(id int, table string, collectionMetric *utils.CollectionMetr
 		return nil
 	}
 
-	converter := protocal.NewConverter(conf.Options.ConvertType)
+	converter := protocol.NewConverter(conf.Options.ConvertType)
 	if converter == nil {
 		LOG.Error("tableSyncer[%v] with table[%v] create converter failed", id, table)
 		return nil

--- a/nimo-shake/incr-sync/syncer.go
+++ b/nimo-shake/incr-sync/syncer.go
@@ -12,7 +12,7 @@ import (
 	"nimo-shake/checkpoint"
 	utils "nimo-shake/common"
 	conf "nimo-shake/configure"
-	"nimo-shake/protocal"
+	"nimo-shake/protocol"
 	"nimo-shake/qps"
 	"nimo-shake/writer"
 
@@ -134,7 +134,7 @@ type Dispatcher struct {
 	targetWriter              writer.Writer
 	batchChan                 chan *dynamodbstreams.Record
 	executorChan              chan *ExecuteNode
-	converter                 protocal.Converter
+	converter                 protocol.Converter
 	ns                        utils.NS
 	checkpointPosition        string
 	checkpointApproximateTime string
@@ -167,7 +167,7 @@ func NewDispatcher(id int, shard *utils.ShardNode, ckptWriter checkpoint.Writer,
 	}
 
 	// converter
-	converter := protocal.NewConverter(conf.Options.ConvertType)
+	converter := protocol.NewConverter(conf.Options.ConvertType)
 	if converter == nil {
 		LOG.Crashf("table[%s] create converter[%v] failed", conf.Options.ConvertType)
 	}
@@ -476,8 +476,8 @@ func (d *Dispatcher) batcher() {
 
 			switch d.targetWriter.(type) {
 			case *writer.MongoCommunityWriter:
-				node.operate = append(node.operate, value.(protocal.RawData).Data)
-				node.index = append(node.index, index.(protocal.RawData).Data)
+				node.operate = append(node.operate, value.(protocol.RawData).Data)
+				node.index = append(node.index, index.(protocol.RawData).Data)
 			case *writer.DynamoProxyWriter:
 				node.operate = append(node.operate, value)
 				node.index = append(node.index, index)
@@ -492,8 +492,8 @@ func (d *Dispatcher) batcher() {
 
 			switch d.targetWriter.(type) {
 			case *writer.MongoCommunityWriter:
-				node.operate = append(node.operate, value.(protocal.RawData).Data)
-				node.index = append(node.index, index.(protocal.RawData).Data)
+				node.operate = append(node.operate, value.(protocol.RawData).Data)
+				node.index = append(node.index, index.(protocol.RawData).Data)
 			case *writer.DynamoProxyWriter:
 				node.operate = append(node.operate, value)
 				node.index = append(node.index, index)
@@ -503,7 +503,7 @@ func (d *Dispatcher) batcher() {
 		case EventRemove:
 			switch d.targetWriter.(type) {
 			case *writer.MongoCommunityWriter:
-				node.index = append(node.index, index.(protocal.RawData).Data)
+				node.index = append(node.index, index.(protocol.RawData).Data)
 			case *writer.DynamoProxyWriter:
 				node.index = append(node.index, index)
 			default:

--- a/nimo-shake/incr-sync/syncer_test.go
+++ b/nimo-shake/incr-sync/syncer_test.go
@@ -1,22 +1,22 @@
 package incr_sync
 
 import (
+	"fmt"
 	"testing"
 	"time"
-	"fmt"
 
-	"nimo-shake/common"
 	"nimo-shake/checkpoint"
-	"nimo-shake/protocal"
+	"nimo-shake/common"
 	"nimo-shake/configure"
+	"nimo-shake/protocol"
 	"nimo-shake/writer"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/aws/aws-sdk-go/service/dynamodbstreams"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/vinllen/mgo/bson"
+	"github.com/aws/aws-sdk-go/service/dynamodbstreams"
+	"github.com/stretchr/testify/assert"
 	"github.com/vinllen/mgo"
+	"github.com/vinllen/mgo/bson"
 )
 
 const (
@@ -36,7 +36,7 @@ func TestBatcher(t *testing.T) {
 		fmt.Printf("TestBatcher case %d.\n", nr)
 		nr++
 
-		converter := protocal.NewConverter("raw")
+		converter := protocol.NewConverter("raw")
 		assert.Equal(t, true, converter != nil, "should be equal")
 
 		d := &Dispatcher{
@@ -93,7 +93,7 @@ func TestBatcher(t *testing.T) {
 		fmt.Printf("TestBatcher case %d.\n", nr)
 		nr++
 
-		converter := protocal.NewConverter("raw")
+		converter := protocol.NewConverter("raw")
 		assert.Equal(t, true, converter != nil, "should be equal")
 
 		d := &Dispatcher{
@@ -198,7 +198,7 @@ func TestBatcher(t *testing.T) {
 		fmt.Printf("TestBatcher case %d.\n", nr)
 		nr++
 
-		converter := protocal.NewConverter("raw")
+		converter := protocol.NewConverter("raw")
 		assert.Equal(t, true, converter != nil, "should be equal")
 
 		d := &Dispatcher{
@@ -325,7 +325,7 @@ func TestBatcher(t *testing.T) {
 		fmt.Printf("TestBatcher case %d.\n", nr)
 		nr++
 
-		converter := protocal.NewConverter("raw")
+		converter := protocol.NewConverter("raw")
 		assert.Equal(t, true, converter != nil, "should be equal")
 
 		d := &Dispatcher{
@@ -403,7 +403,7 @@ func TestBatcher_Executor(t *testing.T) {
 		targetClient, err := utils.NewMongoConn(TestMongoAddress, utils.ConnectModePrimary, true)
 		assert.Equal(t, nil, err, "should be equal")
 
-		converter := protocal.NewConverter("raw")
+		converter := protocol.NewConverter("raw")
 		assert.Equal(t, true, converter != nil, "should be equal")
 
 		d := &Dispatcher{
@@ -415,7 +415,7 @@ func TestBatcher_Executor(t *testing.T) {
 				Collection: "utTestCollection",
 			},
 			unitTestStr: "test",
-			metric: utils.NewMetric(utils.TypeIncr, utils.METRIC_CKPT_TIMES|utils.METRIC_SUCCESS|utils.METRIC_TPS),
+			metric:      utils.NewMetric(utils.TypeIncr, utils.METRIC_CKPT_TIMES|utils.METRIC_SUCCESS|utils.METRIC_TPS),
 		}
 		d.targetWriter = writer.NewWriter(conf.Options.TargetType, conf.Options.TargetAddress, d.ns, conf.Options.LogLevel)
 		d.targetWriter.DropTable()
@@ -484,7 +484,7 @@ func TestBatcher_Executor(t *testing.T) {
 		targetClient, err := utils.NewMongoConn(TestMongoAddress, utils.ConnectModePrimary, true)
 		assert.Equal(t, nil, err, "should be equal")
 
-		converter := protocal.NewConverter("raw")
+		converter := protocol.NewConverter("raw")
 		assert.Equal(t, true, converter != nil, "should be equal")
 
 		d := &Dispatcher{
@@ -496,7 +496,7 @@ func TestBatcher_Executor(t *testing.T) {
 				Collection: "utTestCollection",
 			},
 			unitTestStr: "test",
-			metric: utils.NewMetric(utils.TypeIncr, utils.METRIC_CKPT_TIMES|utils.METRIC_SUCCESS|utils.METRIC_TPS),
+			metric:      utils.NewMetric(utils.TypeIncr, utils.METRIC_CKPT_TIMES|utils.METRIC_SUCCESS|utils.METRIC_TPS),
 		}
 		d.targetWriter = writer.NewWriter(conf.Options.TargetType, conf.Options.TargetAddress, d.ns, conf.Options.LogLevel)
 		d.targetWriter.DropTable()
@@ -605,7 +605,7 @@ func TestBatcher_Executor(t *testing.T) {
 		err := ckpt.DropAll()
 		assert.Equal(t, nil, err, "should be equal")
 
-		converter := protocal.NewConverter("raw")
+		converter := protocol.NewConverter("raw")
 		assert.Equal(t, true, converter != nil, "should be equal")
 
 		targetClient, err := utils.NewMongoConn(TestMongoAddress, utils.ConnectModePrimary, true)
@@ -620,7 +620,7 @@ func TestBatcher_Executor(t *testing.T) {
 				Collection: "utTestCollection",
 			},
 			unitTestStr: "test",
-			metric: utils.NewMetric(utils.TypeIncr, utils.METRIC_CKPT_TIMES|utils.METRIC_SUCCESS|utils.METRIC_TPS),
+			metric:      utils.NewMetric(utils.TypeIncr, utils.METRIC_CKPT_TIMES|utils.METRIC_SUCCESS|utils.METRIC_TPS),
 		}
 		d.targetWriter = writer.NewWriter(conf.Options.TargetType, conf.Options.TargetAddress, d.ns, conf.Options.LogLevel)
 		d.targetWriter.DropTable()
@@ -742,7 +742,7 @@ func TestBatcher_Executor(t *testing.T) {
 		err := ckpt.DropAll()
 		assert.Equal(t, nil, err, "should be equal")
 
-		converter := protocal.NewConverter("raw")
+		converter := protocol.NewConverter("raw")
 		assert.Equal(t, true, converter != nil, "should be equal")
 
 		targetClient, err := utils.NewMongoConn(TestMongoAddress, utils.ConnectModePrimary, true)
@@ -751,7 +751,7 @@ func TestBatcher_Executor(t *testing.T) {
 
 		// create index
 		err = targetClient.Session.DB("utTestDB").C("utTestCollection").EnsureIndex(mgo.Index{
-			Key: []string{"key0"},
+			Key:    []string{"key0"},
 			Unique: true,
 		})
 		assert.Equal(t, nil, err, "should be equal")
@@ -765,7 +765,7 @@ func TestBatcher_Executor(t *testing.T) {
 				Collection: "utTestCollection",
 			},
 			unitTestStr: "test",
-			metric: utils.NewMetric(utils.TypeIncr, utils.METRIC_CKPT_TIMES|utils.METRIC_SUCCESS|utils.METRIC_TPS),
+			metric:      utils.NewMetric(utils.TypeIncr, utils.METRIC_CKPT_TIMES|utils.METRIC_SUCCESS|utils.METRIC_TPS),
 		}
 		d.targetWriter = writer.NewWriter(conf.Options.TargetType, conf.Options.TargetAddress, d.ns, conf.Options.LogLevel)
 
@@ -886,7 +886,7 @@ func TestBatcher_Executor(t *testing.T) {
 		err := ckpt.DropAll()
 		assert.Equal(t, nil, err, "should be equal")
 
-		converter := protocal.NewConverter("raw")
+		converter := protocol.NewConverter("raw")
 		assert.Equal(t, true, converter != nil, "should be equal")
 
 		targetClient, err := utils.NewMongoConn(TestMongoAddress, utils.ConnectModePrimary, true)
@@ -909,7 +909,7 @@ func TestBatcher_Executor(t *testing.T) {
 				Collection: "utTestCollection",
 			},
 			unitTestStr: "test",
-			metric: utils.NewMetric(utils.TypeIncr, utils.METRIC_CKPT_TIMES|utils.METRIC_SUCCESS|utils.METRIC_TPS),
+			metric:      utils.NewMetric(utils.TypeIncr, utils.METRIC_CKPT_TIMES|utils.METRIC_SUCCESS|utils.METRIC_TPS),
 		}
 		d.targetWriter = writer.NewWriter(conf.Options.TargetType, conf.Options.TargetAddress, d.ns, conf.Options.LogLevel)
 
@@ -1038,7 +1038,7 @@ func TestBatcher_Executor(t *testing.T) {
 		err := ckpt.DropAll()
 		assert.Equal(t, nil, err, "should be equal")
 
-		converter := protocal.NewConverter("raw")
+		converter := protocol.NewConverter("raw")
 		assert.Equal(t, true, converter != nil, "should be equal")
 
 		targetClient, err := utils.NewMongoConn(TestMongoAddress, utils.ConnectModePrimary, true)
@@ -1061,7 +1061,7 @@ func TestBatcher_Executor(t *testing.T) {
 				Collection: "utTestCollection",
 			},
 			unitTestStr: "test",
-			metric: utils.NewMetric(utils.TypeIncr, utils.METRIC_CKPT_TIMES|utils.METRIC_SUCCESS|utils.METRIC_TPS),
+			metric:      utils.NewMetric(utils.TypeIncr, utils.METRIC_CKPT_TIMES|utils.METRIC_SUCCESS|utils.METRIC_TPS),
 		}
 		d.targetWriter = writer.NewWriter(conf.Options.TargetType, conf.Options.TargetAddress, d.ns, conf.Options.LogLevel)
 

--- a/nimo-shake/protocol/converter_test.go
+++ b/nimo-shake/protocol/converter_test.go
@@ -1,4 +1,4 @@
-package protocal
+package protocol
 
 import (
 	"fmt"

--- a/nimo-shake/protocol/mtype_converter.go
+++ b/nimo-shake/protocol/mtype_converter.go
@@ -1,4 +1,4 @@
-package protocal
+package protocol
 
 import (
 	"fmt"

--- a/nimo-shake/protocol/protocol.go
+++ b/nimo-shake/protocol/protocol.go
@@ -1,4 +1,4 @@
-package protocal
+package protocol
 
 import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"

--- a/nimo-shake/protocol/raw_converter.go
+++ b/nimo-shake/protocol/raw_converter.go
@@ -1,4 +1,4 @@
-package protocal
+package protocol
 
 import (
 	"fmt"

--- a/nimo-shake/protocol/same_converter.go
+++ b/nimo-shake/protocol/same_converter.go
@@ -1,4 +1,4 @@
-package protocal
+package protocol
 
 import "github.com/aws/aws-sdk-go/service/dynamodb"
 

--- a/nimo-shake/protocol/type_converter.go
+++ b/nimo-shake/protocol/type_converter.go
@@ -1,4 +1,4 @@
-package protocal
+package protocol
 
 import (
 	"fmt"


### PR DESCRIPTION
   Fixe #35 
  - 新增 checkMode 参数，支持选择校验方向：
    - 'mongodb'：以 MongoDB 为基准（遍历 MongoDB，校验 DynamoDB）【新增】
    - 'dynamodb'：以 DynamoDB 为基准（遍历 DynamoDB，校验 MongoDB）【原有逻辑】
  - 添加 checkMode 参数校验，拒绝无效值
  - 默认值设为 'dynamodb'，与原有行为保持一致
  - 修复 sample=0 的行为：现在表示对比全部数据，而非不对比任何数据
  - 更新参数描述和注释
  
